### PR TITLE
ts_close segfault fix

### DIFF
--- a/src/ts_close.c
+++ b/src/ts_close.c
@@ -22,15 +22,19 @@ int ts_close(struct tsdev *ts)
 {
 	void *handle;
 	int ret;
-	struct tslib_module_info *info, *prev;
-
-	for(info = ts->list, prev = info;
-	    info != NULL;
-	    info = prev->next, prev = info) {
+	struct tslib_module_info *info, *next;
+	
+	info = ts->list;
+	while(info) {
+		/* Save the "next" pointer now because info will be freed */
+		next = info->next;
+		
 		handle = info->handle;
 		info->ops->fini(info);
 		if (handle)
 			dlclose(handle);
+		
+		info = next;
 	}
 
 	ret = close(ts->fd);


### PR DESCRIPTION
Hi there,

This patch fixes a segfault when ts_close() is called and more than one module is attached. I changed the loop through the linked list of modules to save the "next" pointer before calling fini().
