### PR TITLE
Replace calls to printf / fprintf / perror with calls to ts_error

### DIFF
--- a/plugins/cy8mrln-palmpre.c
+++ b/plugins/cy8mrln-palmpre.c
@@ -134,7 +134,7 @@ static int cy8mrln_palmpre_set_scanrate(struct tslib_cy8mrln_palmpre* info, int 
 	return 0;
 	
 error:
-	printf("TSLIB: cy8mrln_palmpre: ERROR: could not set scanrate value\n");
+	ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set scanrate value\n");
 	return -1;
 }
 
@@ -147,7 +147,7 @@ static int cy8mrln_palmpre_set_verbose(struct tslib_cy8mrln_palmpre* info, int v
 	return 0;
 
 error:
-	printf("TSLIB: cy8mrln_palmpre: ERROR: could not set verbose value\n");
+	ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set verbose value\n");
 	return -1;
 }
 
@@ -160,7 +160,7 @@ static int cy8mrln_palmpre_set_sleepmode(struct tslib_cy8mrln_palmpre* info, int
 	return 0;
 	
 error:
-	printf("TSLIB: cy8mrln_palmpre: ERROR: could not set sleepmode value\n");
+	ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set sleepmode value\n");
 	return -1;
 }
 
@@ -173,7 +173,7 @@ static int cy8mrln_palmpre_set_wot_scanrate(struct tslib_cy8mrln_palmpre* info, 
 	return 0;
 
 error:
-	printf("TSLIB: cy8mrln_palmpre: ERROR: could not set scanrate value\n");
+	ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set scanrate value\n");
 	return -1;
 }
 
@@ -190,7 +190,7 @@ static int cy8mrln_palmpre_set_wot_threshold(struct tslib_cy8mrln_palmpre* info,
 	return 0;
 	
 error:
-	printf("TSLIB: cy8mrln_palmpre: ERROR: could not set wot treshhold value\n");
+	ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set wot treshhold value\n");
 	return -1;
 }
 
@@ -203,14 +203,14 @@ static int cy8mrln_palmpre_set_timestamp_mode(struct tslib_cy8mrln_palmpre* info
 	return 0;
 	
 error:
-	printf("TSLIB: cy8mrln_palmpre: ERROR: could not set timestamp value\n");
+	ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set timestamp value\n");
 	return -1;
 }
 
 static int cy8mrln_palmpre_set_gesture_height (struct tslib_cy8mrln_palmpre* info, int h)
 {
 	if (info == NULL) {
-		printf("TSLIB: cy8mrln_palmpre: ERROR: could not set gesture_height value\n");
+		ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set gesture_height value\n");
 		return -1;
 	}
 
@@ -222,7 +222,7 @@ static int cy8mrln_palmpre_set_gesture_height (struct tslib_cy8mrln_palmpre* inf
 static int cy8mrln_palmpre_set_noise (struct tslib_cy8mrln_palmpre* info, int n)
 {
 	if (info == NULL) {
-		printf("TSLIB: cy8mrln_palmpre: ERROR: could not set noise value\n");
+		ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set noise value\n");
 		return -1;
 	}
 
@@ -234,7 +234,7 @@ static int cy8mrln_palmpre_set_noise (struct tslib_cy8mrln_palmpre* info, int n)
 static int cy8mrln_palmpre_set_pressure (struct tslib_cy8mrln_palmpre* info, int p)
 {
 	if (info == NULL) {
-		printf("TSLIB: cy8mrln_palmpre: ERROR: could not set default_pressure value\n");
+		ts_error("TSLIB: cy8mrln_palmpre: ERROR: could not set default_pressure value\n");
 		return -1;
 	}
 

--- a/plugins/dmc-raw.c
+++ b/plugins/dmc-raw.c
@@ -52,28 +52,28 @@ int dmc_init_device(struct tsdev *dev)
 	tcsetattr(fd, TCSANOW, &t);
 
 	if (write(fd, "\x55", 1) != 1) {
-		fprintf(stderr, "dmc: failed to write. Check permissions of the device!\n");
+		ts_error("dmc: failed to write. Check permissions of the device!\n");
 		return EINVAL;
 	}
 	sleep(1);
 	if (write(fd, "\x05\x40", 2) != 2) {
-		perror("dmc write");
+		ts_error("dmc write: %s\n", strerror(errno));
 		goto fail;
 	}
 	if (read(fd, buf, 1) != 1) {
-		perror("dmc read");
+		ts_error("dmc read: %s\n", strerror(errno));
 		goto fail;
 	}
 	if (buf[0] != 0x6) {
-		fprintf(stderr, "dmc: got wrong return value. The touchscreen may not work.\n");
+		ts_error("dmc: got wrong return value. The touchscreen may not work.\n");
 	}
 	if (write(fd, "\x31", 1) != 1) {
-		perror("dmc write");
+		ts_error("dmc write: %s\n", strerror(errno));
 		goto fail;
 	}
 	return 0;
 fail:
-	fprintf(stderr, "dmc: selected device is not a touchscreen I understand\n");
+	ts_error("dmc: selected device is not a touchscreen I understand\n");
 	return EINVAL;
 }
 

--- a/plugins/input-raw.c
+++ b/plugins/input-raw.c
@@ -79,26 +79,26 @@ static int check_fd(struct tslib_input *i)
 	long keybit[BITS_TO_LONGS(KEY_CNT)];
 
 	if (ioctl(ts->fd, EVIOCGVERSION, &version) < 0) {
-		fprintf(stderr, "tslib: Selected device is not a Linux input event device\n");
+		ts_error("tslib: Selected device is not a Linux input event device\n");
 		return -1;
 	}
 
 	if (version < EV_VERSION) {
-		fprintf(stderr, "tslib: Selected device uses a different version of the event protocol than tslib was compiled for\n");
+		ts_error("tslib: Selected device uses a different version of the event protocol than tslib was compiled for\n");
 		return -1;
 	}
 
 	if ( (ioctl(ts->fd, EVIOCGBIT(0, sizeof(evbit)), evbit) < 0) ||
 		!(evbit[BIT_WORD(EV_ABS)] & BIT_MASK(EV_ABS)) ||
 		!(evbit[BIT_WORD(EV_KEY)] & BIT_MASK(EV_KEY)) ) {
-		fprintf(stderr, "tslib: Selected device is not a touchscreen (must support ABS and KEY event types)\n");
+		ts_error("tslib: Selected device is not a touchscreen (must support ABS and KEY event types)\n");
 		return -1;
 	}
 
 	if ((ioctl(ts->fd, EVIOCGBIT(EV_ABS, sizeof(absbit)), absbit)) < 0 ||
 		!(absbit[BIT_WORD(ABS_X)] & BIT_MASK(ABS_X)) ||
 		!(absbit[BIT_WORD(ABS_Y)] & BIT_MASK(ABS_Y))) {
-		fprintf(stderr, "tslib: Selected device is not a touchscreen (must support ABS_X and ABS_Y events)\n");
+		ts_error("tslib: Selected device is not a touchscreen (must support ABS_X and ABS_Y events)\n");
 		return -1;
 	}
 
@@ -112,7 +112,7 @@ static int check_fd(struct tslib_input *i)
 
 		if ((ioctl(ts->fd, EVIOCGBIT(EV_KEY, sizeof(keybit)), keybit) < 0) ||
 			!(keybit[BIT_WORD(BTN_TOUCH)] & BIT_MASK(BTN_TOUCH)) ) {
-			fprintf(stderr, "tslib: Selected device is not a touchscreen (must support BTN_TOUCH events)\n");
+			ts_error("tslib: Selected device is not a touchscreen (must support BTN_TOUCH events)\n");
 			return -1;
 		}
 	}
@@ -122,7 +122,7 @@ static int check_fd(struct tslib_input *i)
 
 	if (i->grab_events == GRAB_EVENTS_WANTED) {
 		if (ioctl(ts->fd, EVIOCGRAB, (void *)1)) {
-			fprintf(stderr, "tslib: Unable to grab selected input device\n");
+			ts_error("tslib: Unable to grab selected input device\n");
 			return -1;
 		}
 		i->grab_events = GRAB_EVENTS_ACTIVE;
@@ -240,7 +240,7 @@ static int ts_input_read(struct tslib_module_info *inf,
 						samp->y = i->current_y;
 						samp->pressure = i->current_p;
 					} else {
-						fprintf(stderr, "tslib: dropped x = 0\n");
+						ts_error("tslib: dropped x = 0\n");
 						continue;
 					}
 					break;
@@ -250,7 +250,7 @@ static int ts_input_read(struct tslib_module_info *inf,
 						samp->y = i->current_y = ev.value;
 						samp->pressure = i->current_p;
 					} else {
-						fprintf(stderr, "tslib: dropped y = 0\n");
+						ts_error("tslib: dropped y = 0\n");
 						continue;
 					}
 					break;
@@ -282,7 +282,7 @@ static int ts_input_read(struct tslib_module_info *inf,
 					break;
 				}
 			} else {
-				fprintf(stderr, "tslib: Unknown event type %d\n", ev.type);
+				ts_error("tslib: Unknown event type %d\n", ev.type);
 			}
 			p = (unsigned char *) &ev;
 		}
@@ -299,7 +299,7 @@ static int ts_input_fini(struct tslib_module_info *inf)
 
 	if (i->grab_events == GRAB_EVENTS_ACTIVE) {
 		if (ioctl(ts->fd, EVIOCGRAB, (void *)0)) {
-			fprintf(stderr, "tslib: Unable to un-grab selected input device\n");
+			ts_error("tslib: Unable to un-grab selected input device\n");
 		}
 	}
 

--- a/src/ts_config.c
+++ b/src/ts_config.c
@@ -10,6 +10,7 @@
  * Read the configuration and load the appropriate drivers.
  */
 #include "config.h"
+#include <errno.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -37,7 +38,7 @@ int ts_config(struct tsdev *ts)
 
 	f = fopen(conffile, "r");
 	if (!f) {
-		perror("Couldnt open tslib config file");
+		ts_error("Couldnt open tslib config file: %s\n", strerror(errno));
 		return -1;
 	}
 


### PR DESCRIPTION
Consistently use ts_error to report errors, instead of writing them either to stdout (printf) or stderr (fprintf, perror). This allows applications that don't use stdout or stderr to capture the errors easily (and write them to their own log file for example).
