### PR TITLE
Fix build with automake-1.13

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ AC_INIT(tslib, 1.0.0, kergoth@handhelds.org)
 # AC_CONFIG_AUX_DIR(config)
 AM_INIT_AUTOMAKE(dist-bzip2)
 AC_CONFIG_SRCDIR([src/ts_close.c])
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS(config.h)
 
 PACKAGE_DESCRIPTION="Touchscreen Access Library"
 AC_SUBST(PACKAGE_DESCRIPTION)


### PR DESCRIPTION
Replace long obsolete AM_CONFIG_HEADER that makes automake-1.13 to
error out with AC_CONFIG_HEADERS.

Signed-off-by: Marko Lindqvist cazfi74@gmail.com
