### PR TITLE
tools: fix build on FreeBSD

### DIFF
--- a/tools/ts_uinput.c
+++ b/tools/ts_uinput.c
@@ -1,6 +1,7 @@
 /*
  * (C) 2017 Ginzinger electronic systems GmbH, A-4952 Weng im Innkreis
  *
+ * Adriaan de Groot <adridg@FreeBSD.org>  2020-04-15
  * Martin Kepplinger <martin.kepplinger@ginzinger.com>  2016-09-14
  * Melchior FRANZ <melchior.franz@ginzinger.com>  2015-09-30
  *
@@ -361,6 +362,23 @@ static int send_touch_events(struct data_t *data, struct ts_sample_mt **s,
 
 static int get_abs_max_fb(struct data_t *data, int *max_x, int *max_y)
 {
+#ifdef __FreeBSD__
+	struct fbtype fbinfo;
+
+	if (ioctl(data->fd_fb, FBIOGTYPE, &fbinfo) < 0) {
+		perror("ioctl FBIOGTYPE");
+		return errno;
+	}
+
+	if ((fbinfo.fb_width == 0) || (fbinfo.fb_height == 0)) {
+		/* Bogus w/h, guess something */
+		*max_x = 320 - 1;
+		*max_y = 240 - 1;
+	} else {
+		*max_x = fbinfo.fb_width - 1;
+		*max_y = fbinfo.fb_height - 1;
+	}
+#else
 	struct fb_var_screeninfo fbinfo;
 
 	if (ioctl(data->fd_fb, FBIOGET_VSCREENINFO, &fbinfo) < 0) {
@@ -370,7 +388,7 @@ static int get_abs_max_fb(struct data_t *data, int *max_x, int *max_y)
 
 	*max_x = fbinfo.xres - 1;
 	*max_y = fbinfo.yres - 1;
-
+#endif
 	return 0;
 }
 


### PR DESCRIPTION
`ts_uinput` didn't build. Now it does.