### PR TITLE
ts_config: ckeck pointer before calling sprintf

### DIFF
--- a/src/ts_config.c
+++ b/src/ts_config.c
@@ -131,7 +131,7 @@ static int __ts_config(struct tsdev *ts, char **conffile_modules,
 					module_name, p);
 			#endif
 				sprintf(conffile_modules[line], "%s", module_name);
-				if (conffile_params)
+				if (conffile_params && p)
 					sprintf(conffile_params[line], "%s", p);
 			}
 		} else if (strcasecmp(tok, "module_raw") == 0) {
@@ -149,7 +149,7 @@ static int __ts_config(struct tsdev *ts, char **conffile_modules,
 					module_name, p);
 			#endif
 				sprintf(conffile_modules[line], "%s", module_name);
-				if (conffile_params)
+				if (conffile_params && p)
 					sprintf(conffile_params[line], "%s", p);
 
 				if (raw)


### PR DESCRIPTION
This avoids a Segmentation fault when running ts_conf to show ts.conf modules and this change is required as a result of this commit https://github.com/libts/tslib/commit/7ee93a73103b76dca7b635bb2cb2018fbe98c175