### PR TITLE
ts_conf: Fix unbounded write by scanf()

### DIFF
--- a/tests/ts_conf.c
+++ b/tests/ts_conf.c
@@ -157,14 +157,14 @@ static int add_line_after(struct ts_module_conf *conf)
 		goto err;
 
 	printf("new module name without parameters: ");
-	ret = scanf("%s", new_filter->name);
+	ret = scanf("%1023s", new_filter->name);
 	if (ret <= 0) {
 		perror("scanf");
 		goto err;
 	}
 	printf("parameters: ");
 	while ((c = getchar()) != '\n' && c != EOF) { }
-	ret = scanf("%[^\n]s", new_filter->params);
+	ret = scanf("%1023[^\n]", new_filter->params);
 	if (ret < 0)
 		goto err;
 	new_filter->nr = ++nr;


### PR DESCRIPTION
Buffer write operations that do not control the length of data written may overflow.

Also, the scanf format string "%[^\n]s" is ill-formed. It contains two independent format specifiers: "%[^\n]" followed by a lone "s". This will direct scanf to read everything until \n is encountered (leaving \n unread), and then require that the next input character is s. This just doesn't make any sense. No input will match such self-contradictory format.
Reference: https://stackoverflow.com/questions/8177752/scanf-ns-a-vs-getsa