### PR TITLE
plugins: input-raw: Parse BTN_LEFT in MT mode

### DIFF
--- a/plugins/input-raw.c
+++ b/plugins/input-raw.c
@@ -657,6 +657,7 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
 			case EV_KEY:
 				switch (i->ev[it].code) {
 				case BTN_TOUCH:
+				case BTN_LEFT:
 					i->buf[total][i->slot].pen_down = i->ev[it].value;
 					i->buf[total][i->slot].tv.tv_sec = i->ev[it].input_event_sec;
 					i->buf[total][i->slot].tv.tv_usec = i->ev[it].input_event_usec;


### PR DESCRIPTION
Some devices, like eGalax USB HID touch panel, emulate a mouse device. In such case, BTN_LEFT instead of BTN_TOUCH event is read from evdev input. This case is already covered in `ts_input_read()`, but not in the `ts_input_read_mt()`. As `ts_uinput` tool always uses multitouch mode, such devices do not register touch events correctly.

Handle BTN_LEFT in the same way as BTN_TOUCH is handled to fix this problem. This will now be common with `ts_input_read()` implementation.