### PR TITLE
Improve ts_uinput_start.sh script

### DIFF
--- a/tools/ts_uinput_start.sh
+++ b/tools/ts_uinput_start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # SPDX-License-Identifier: GPL-2.0+
 # Copyright (C) 2017, Martin Kepplinger <martink@posteo.de>
 

--- a/tools/ts_uinput_start.sh
+++ b/tools/ts_uinput_start.sh
@@ -5,13 +5,12 @@
 # This starts ts_uinput as a daemon and creates /dev/input/ts_uinput to use
 # as an evdev input device
 
-TS_UINPUT_DEV_FILE=$(ts_uinput -d -v)
-TS_UINPUT_DEV_FILE_CHECKED=$(ls "$TS_UINPUT_DEV_FILE" | grep 'event')
+TS_UINPUT_DEV_FILE=$(ts_uinput -d -v | grep 'event')
 
-if [ ! -z "$TS_UINPUT_DEV_FILE_CHECKED" ]
+if [ -n "$TS_UINPUT_DEV_FILE" ]
 then
 	rm -f /dev/input/ts_uinput
-	ln -s $TS_UINPUT_DEV_FILE_CHECKED /dev/input/ts_uinput
+	ln -s "$TS_UINPUT_DEV_FILE" /dev/input/ts_uinput
 else
 	echo "ts_uinput: Error creating event device"
 	exit 1


### PR DESCRIPTION
Running shellcheck on this script reported following problems: SC2010, SC2086, SC2236.

This MR includes following changes to  `ts_uinput_start.sh` script:
- Make script more portable by using `sh`
- Fix warnings reported by shellcheck
