### PR TITLE
Return the correct name during a device scan

### DIFF
--- a/src/ts_setup.c
+++ b/src/ts_setup.c
@@ -85,15 +85,7 @@ static char *scan_devices(void)
 			continue;
 		} else {
 			close(fd);
-			filename = malloc(strlen(DEV_INPUT_EVENT) +
-					  strlen(EVENT_DEV_NAME) +
-					  12);
-			if (!filename)
-				break;
-
-			sprintf(filename, "%s/%s%d",
-				DEV_INPUT_EVENT, EVENT_DEV_NAME,
-				i);
+			filename = strdup(fname);
 			break;
 		}
 	}


### PR DESCRIPTION
In scan_device(), the returned device name was computed wrongly. It is opened a device, then if it was found as touchscreen it is computed the name again in a different way.
It is better (and simpler) to return a strdup() of  the last successfully opened device.

I suspect that in may setup I faced the bug because I have a number of entries > 9 and this create an arrangement of entries where 
```
      snprintf(fname, sizeof(fname),
                         "%s/%s", DEV_INPUT_EVENT, namelist[i]->d_name);
      sprintf(filename, "%s/%s%d",
                         DEV_INPUT_EVENT, EVENT_DEV_NAME,
                         i);
    fname <> filename
```