### PR TITLE
fix printf with 64bit time_t

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,9 +585,9 @@ This is a complete example program, similar to `ts_print_mt.c`:
 					continue;
 			#endif
 
-				printf("%ld.%06ld: (slot %d) %6d %6d %6d\n",
-				       samp_mt[j][i].tv.tv_sec,
-				       samp_mt[j][i].tv.tv_usec,
+				printf("%lld.%06lld: (slot %d) %6d %6d %6d\n",
+				       (long long)samp_mt[j][i].tv.tv_sec,
+				       (long long)samp_mt[j][i].tv.tv_usec,
 				       samp_mt[j][i].slot,
 				       samp_mt[j][i].x,
 				       samp_mt[j][i].y,

--- a/plugins/input-evdev-raw.c
+++ b/plugins/input-evdev-raw.c
@@ -461,11 +461,11 @@ static int ts_input_read(struct tslib_module_info *inf,
 				samp->tv = ev.time;
 		#ifdef DEBUG
 			fprintf(stderr,
-				"RAW nr %d ---------------------> %d %d %d %ld.%ld\n",
+				"RAW nr %d ---------------------> %d %d %d %lld.%06lld\n",
 				total,
 				samp->x, samp->y, samp->pressure,
-				(long)samp->tv.tv_sec,
-				(long)samp->tv.tv_usec);
+				(long long)samp->tv.tv_sec,
+				(long long)samp->tv.tv_usec);
 		#endif /* DEBUG */
 				samp++;
 				total++;
@@ -651,11 +651,11 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
 		}
 
 	#ifdef DEBUG
-		printf("INPUT-RAW nr %d: read type %d  code %3d  value %4d  time %ld.%ld\n",
+		printf("INPUT-RAW nr %d: read type %d  code %3d  value %4d  time %lld.%06lld\n",
 		       total,
-		       ev.type, ev.code,
-		       ev.value, (long)ev.time.tv_sec,
-		       (long)ev.time.tv_usec);
+		       ev.type, ev.code, ev.value,
+		       (long long)ev.time.tv_sec,
+		       (long long)ev.time.tv_usec);
 	#endif
 		switch (ev.type) {
 		case EV_KEY:

--- a/plugins/input-raw.c
+++ b/plugins/input-raw.c
@@ -393,10 +393,10 @@ static int ts_input_read(struct tslib_module_info *inf,
 					samp->tv.tv_usec = ev.input_event_usec;
 			#ifdef DEBUG
 				fprintf(stderr,
-					"RAW---------------------> %d %d %d %ld.%ld\n",
+					"RAW---------------------> %d %d %d %lld.%06lld\n",
 					samp->x, samp->y, samp->pressure,
-					(long)samp->tv.tv_sec,
-					(long)samp->tv.tv_usec);
+					(long long)samp->tv.tv_sec,
+					(long long)samp->tv.tv_usec);
 			#endif /* DEBUG */
 					samp++;
 					total++;
@@ -648,10 +648,10 @@ static int ts_input_read_mt(struct tslib_module_info *inf,
 
 		for (it = 0; it < rd / sizeof(struct input_event); it++) {
 		#ifdef DEBUG
-			printf("INPUT-RAW: read type %d  code %3d  value %4d  time %ld.%ld\n",
+			printf("INPUT-RAW: read type %d  code %3d  value %4d  time %lld.%06lld\n",
 			       i->ev[it].type, i->ev[it].code,
-			       i->ev[it].value, (long)i->ev[it].input_event_sec,
-			       (long)i->ev[it].input_event_usec);
+			       i->ev[it].value, (long long)i->ev[it].input_event_sec,
+			       (long long)i->ev[it].input_event_usec);
 		#endif
 			switch (i->ev[it].type) {
 			case EV_KEY:

--- a/tests/ts_print.c
+++ b/tests/ts_print.c
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 		if (ret != 1)
 			continue;
 
-		printf("%ld.%06ld: %6d %6d %6d\n", samp.tv.tv_sec, samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
+		printf("%lld.%06lld: %6d %6d %6d\n", (long long)samp.tv.tv_sec, (long long)samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
 
 	}
 

--- a/tests/ts_print_mt.c
+++ b/tests/ts_print_mt.c
@@ -241,10 +241,10 @@ int main(int argc, char **argv)
 				if (!(samp_mt[j][i].valid & TSLIB_MT_VALID))
 					continue;
 
-				printf(YELLOW "sample %d - %ld.%06ld -" RESET " (slot %d) %6d %6d %6d\n",
+				printf(YELLOW "sample %d - %lld.%06lld -" RESET " (slot %d) %6d %6d %6d\n",
 				       j,
-				       samp_mt[j][i].tv.tv_sec,
-				       samp_mt[j][i].tv.tv_usec,
+				       (long long)samp_mt[j][i].tv.tv_sec,
+				       (long long)samp_mt[j][i].tv.tv_usec,
 				       samp_mt[j][i].slot,
 				       samp_mt[j][i].x,
 				       samp_mt[j][i].y,

--- a/tests/ts_print_raw.c
+++ b/tests/ts_print_raw.c
@@ -83,7 +83,7 @@ int main(int argc, char **argv)
 		if (ret != 1)
 			continue;
 
-		printf("%ld.%06ld: %6d %6d %6d\n", samp.tv.tv_sec, samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
+		printf("%lld.%06lld: %6d %6d %6d\n", (long long)samp.tv.tv_sec, (long long)samp.tv.tv_usec, samp.x, samp.y, samp.pressure);
 
 	}
 

--- a/tests/ts_test.c
+++ b/tests/ts_test.c
@@ -202,7 +202,7 @@ int main(int argc, char **argv)
 					quit_pressed = 1;
 				}
 
-		printf("%ld.%06ld: %6d %6d %6d\n", samp.tv.tv_sec, samp.tv.tv_usec,
+		printf("%lld.%06lld: %6d %6d %6d\n", (long long)samp.tv.tv_sec, (long long)samp.tv.tv_usec,
 			samp.x, samp.y, samp.pressure);
 
 		if (samp.pressure > 0) {

--- a/tests/ts_test_mt_sdl.c
+++ b/tests/ts_test_mt_sdl.c
@@ -185,9 +185,9 @@ int main(int argc, char **argv)
 				       samp_mt[0][i].x, samp_mt[0][i].y);
 
 			if (verbose) {
-				printf("%ld.%06ld: (slot %d) %6d %6d %6d\n",
-					samp_mt[0][i].tv.tv_sec,
-					samp_mt[0][i].tv.tv_usec,
+				printf("%lld.%06lld: (slot %d) %6d %6d %6d\n",
+					(long long)samp_mt[0][i].tv.tv_sec,
+					(long long)samp_mt[0][i].tv.tv_usec,
 					samp_mt[0][i].slot,
 					samp_mt[0][i].x,
 					samp_mt[0][i].y,


### PR DESCRIPTION
Printing long long with %ld is UB.
Converting long long to long could overflow.
To be compatible with 32bit time_t we need an explicit cast to long long.