### PR TITLE
CMake: bump minimal required version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.10)
 
 project(tslib LANGUAGES C)
 


### PR DESCRIPTION
CMake 4 requires `cmake_minimum_required` to be at least 3.5, see https://cmake.org/cmake/help/latest/release/4.0.html#id15.

(Discovered in NixOS/nixpkgs#438633.)